### PR TITLE
Fix/counter checkout

### DIFF
--- a/src/apps/Counter/components/Modals/SelectTable.tsx
+++ b/src/apps/Counter/components/Modals/SelectTable.tsx
@@ -40,12 +40,12 @@ export const SelectTable = () => {
             value={item.name}
             onChange={() => setSelectedCheckout(item)}
             checked={selectedCheckout?.id === item.id}
-            disabled={!checkPayStatus(item.orderId, item.status, item.isPay, item.orderDetail?.length)}
+            disabled={!checkPayStatus(item.orderId, item.status, item.isPay, item.orderDetail?.flat().length)}
           />
           <Label htmlFor={item.id} className='checked:text-white'>
             <div className={clsx(
               'px-4 py-2',
-              checkPayStatus(item.orderId, item.status, item.isPay, item.orderDetail?.length) ? 'border-primary text-primary'
+              checkPayStatus(item.orderId, item.status, item.isPay, item.orderDetail?.flat().length) ? 'border-primary text-primary'
                 : 'bg-gray-100 text-black/50',
               'cursor-pointer',
               'rounded-md border text-fs-6',

--- a/src/apps/Counter/components/Modals/SelectTable.tsx
+++ b/src/apps/Counter/components/Modals/SelectTable.tsx
@@ -21,6 +21,7 @@ export const SelectTable = () => {
     if (res) {
       setBill(res);
       setTriggerModal('calculate');
+      setSelectedCheckout(null);
     }
   };
 

--- a/src/apps/Counter/components/Sidebar.tsx
+++ b/src/apps/Counter/components/Sidebar.tsx
@@ -14,7 +14,7 @@ export const Sidebar = () => {
   };
 
   // 計算 list 中 isPayed 為 false 的數量
-  const unpaidCount = list.filter((item) => !checkPayStatus(item.orderId, item.status, item.isPay, item.orderDetail?.length)).length;
+  const unpaidCount = list.filter((item) => checkPayStatus(item.orderId, item.status, item.isPay, item.orderDetail?.flat().length)).length;
 
   return (
   <div

--- a/src/apps/Counter/utils/checkPayStatus.ts
+++ b/src/apps/Counter/utils/checkPayStatus.ts
@@ -1,8 +1,9 @@
 import { TableStatus } from '@/types/order';
 
+// 需結帳
 export const checkPayStatus = (orderId: string, status: string, isPay: boolean, orderDetailLen: number | undefined) => {
-  if (orderId === '') return true;
-  return status && TableStatus.MEAL && !isPay && orderDetailLen && orderDetailLen > 0;
+  if (orderId === '') return false; // 閒置
+  return status === TableStatus.MEAL && !isPay && orderDetailLen && orderDetailLen > 0; // 用餐中、未結帳、已點餐
 };
 
 export default checkPayStatus;


### PR DESCRIPTION
- [ ] 修正廚房端判斷是否結帳條件
- [ ] 修正關閉結帳 modal 時, 需清空 store 中的資訊 ( 情境: 只有一組桌次走完流程後, 再次入座, 因為剛好可結帳的 table 為同桌, 而因為沒有 onchage 重新設定 selectedCheckout,  導致會取得舊 orderId )
