### PR TITLE
fix: 🐛 open modal reset selectedCheckout

### DIFF
--- a/src/apps/Counter/components/Modals/SelectTable.tsx
+++ b/src/apps/Counter/components/Modals/SelectTable.tsx
@@ -21,7 +21,6 @@ export const SelectTable = () => {
     if (res) {
       setBill(res);
       setTriggerModal('calculate');
-      setSelectedCheckout(null);
     }
   };
 

--- a/src/apps/Counter/components/Sidebar.tsx
+++ b/src/apps/Counter/components/Sidebar.tsx
@@ -5,11 +5,12 @@ import { useStore } from '../stores';
 import { checkPayStatus } from '../utils/checkPayStatus';
 
 export const Sidebar = () => {
-  const { setTriggerModal, list } = useStore();
+  const { setTriggerModal, setSelectedCheckout, list } = useStore();
   const { setIsOpen } = useModalStore();
 
   const handleBill = () => {
     setTriggerModal('selectTable');
+    setSelectedCheckout(null);
     setIsOpen(true);
   };
 


### PR DESCRIPTION
應該打開 modal 時, 才清空上次選擇的 checkout table, 才部會造成下一步無法結帳